### PR TITLE
Fix incompatibility with Roundcube 1.3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,14 @@
 	"type": "roundcube-plugin",
 	"description": "XMPP plugin for Roundcube based on Converse.js",
 	"keywords": ["xmpp", "chat", "im", "jabber"],
-	"homepage": "https://github.com/priyadi/roundcube-converse.js-xmpp-plugin",
+	"homepage": "https://github.com/devurandom/roundcube-converse.js-xmpp-plugin",
 	"license": "MIT",
 	"authors": [
+		{
+			"name": "Dennis Schridde",
+			"homepage": "https://github.com/devurandom",
+			"role": "Developer"
+		},
 		{
 			"name": "Priyadi Iman Nurcahyo",
 			"email": "priyadi@priyadi.net",

--- a/converse.php
+++ b/converse.php
@@ -269,7 +269,7 @@ class converse extends rcube_plugin
 				$select->add($this->gettext('manual'), 2);
 			}
 			$p['blocks']['converse']['options']['converse_enable'] = array(
-				'title' => html::label($field_id, Q($this->gettext('enableprebind'))),
+				'title' => (RCUBE_VERSION>="1.3")?html::label($field_id, rcube::Q($this->gettext('enableprebind'))):html::label($field_id, Q($this->gettext('enableprebind'))),
 				'content' => $select->show($rcmail->config->get('converse_prebind', $default)),
 			);
 		}


### PR DESCRIPTION
Fixes the following issue: When the plugin is used with Roundcube 1.3+, "Preferences" -> "User Interface" stops working. In logs/errors the following message appears:

```
[20-Jan-2018 09:42:20 Europe/Berlin] PHP Fatal error:  Uncaught Error: Call to undefined function Q() in /srv/www/roundcube/beta/plugins/converse/converse.php:272
Stack trace:
#0 /srv/www/roundcube/beta/program/lib/Roundcube/rcube_plugin_api.php(440): converse->preferences_list(Array)
#1 /srv/www/roundcube/beta/program/steps/settings/func.inc(1265): rcube_plugin_api->exec_hook('preferences_lis...', Array)
#2 /srv/www/roundcube/beta/program/steps/settings/edit_prefs.inc(28): rcmail_user_prefs('general')
#3 /srv/www/roundcube/beta/index.php(303): include_once('/srv/www/roundc...')
#4 {main}
  thrown in /srv/www/roundcube/beta/plugins/converse/converse.php on line 272
```

This fix should work in older versions, but I only tested with Roundcube 1.3.4